### PR TITLE
feat(sync): Rework geozone sync

### DIFF
--- a/modules/api/sync/README.md
+++ b/modules/api/sync/README.md
@@ -4,7 +4,6 @@
 
 ```console
 docker compose up -d
-docker compose run --rm ogr2ogr ogr2ogr -f "PostgreSQL" PG:"host=pg port=5432 dbname=ecowater user=ecowater password=ecowater" "/app/all_zones.shp" -nln geozone -nlt PROMOTE_TO_MULTI -s_srs "/app/all_zones.prj" -t_srs "EPSG:4326" -lco FID=id -lco GEOMETRY_NAME=geom -progress
 docker compose run --rm app pip install -r requirements.txt
 docker compose run --rm app python index.py
 ```

--- a/modules/api/sync/init.sql
+++ b/modules/api/sync/init.sql
@@ -7,14 +7,8 @@ DROP TABLE IF EXISTS geozone;
 
 CREATE TABLE geozone (
     id SERIAL PRIMARY KEY,
-    id_zone INT,
-    code_zone VARCHAR(32),
-    type_zone VARCHAR(3),
-    nom_zone VARCHAR(200),
-    n_version INT,
-    code_dep VARCHAR(3),
-    nom_dep VARCHAR(60),
-    geom geometry(MultiPolygon, 4326)
+    external_id INT NOT NULL UNIQUE,
+    geometry geometry(MultiPolygon, 4326)
 );
 
 CREATE TABLE decree(

--- a/modules/api/sync/package/data_provider.py
+++ b/modules/api/sync/package/data_provider.py
@@ -2,14 +2,8 @@ import requests
 import json
 import logging
 
-# URL de l'API à appeler en preprod sur demo.data.gouv
-#DATASET='643d5f985c230e2b786c5602'
-#url = 'https://demo.data.gouv.fr/api/1/datasets/' + DATASET
-
-
-# URL de l'API à appeler en prod sur data.gouv
-DATASET='6470b39cfbad66b8c265ada3'
-url = 'https://data.gouv.fr/api/1/datasets/' + DATASET
+# url = 'https://demo.data.gouv.fr/api/1/datasets/643d5f985c230e2b786c5602'
+url = 'https://data.gouv.fr/api/1/datasets/6470b39cfbad66b8c265ada3'
 
 def get_data():
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -23,20 +17,19 @@ def get_data():
 
     data = json.loads(response.text)
     resources = data['resources']
+    urls = {'restictions_url': None, 'decrees_url': None, 'geozones': None}
 
-    restictions_url, decrees_url = None, None
     for resource in resources:
         title = resource['title']
 
         if 'Restriction' in title:
-            restictions_url = resource['url']
+            urls['restictions_url'] = resource['url']
         if 'Arrêtés' == title:
-            decrees_url = resource['url']
+            urls['decrees_url'] = resource['url']
+        if 'Géométrie des zones' in title:
+            urls['geozones'] = resource['url']
 
-    return {
-        'decrees': decrees_url,
-        'restrictions': restictions_url,
-    }
+    return urls
 
 if __name__ == '__main__':
     get_data()

--- a/modules/api/sync/package/decree_repository.py
+++ b/modules/api/sync/package/decree_repository.py
@@ -5,7 +5,6 @@ def find_by_external_id(cursor, external_id: str) -> Optional[Decree]:
     query = 'SELECT * FROM decree WHERE external_id = %s'
     parameters = (external_id,)
     cursor.execute(query, parameters)
-
     result = cursor.fetchone()
 
     if not result:

--- a/modules/api/sync/package/event.py
+++ b/modules/api/sync/package/event.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
 class Event(Enum):
+    GEOZONE_CREATION = 'geozone_creation'
     DECREE_CREATION = 'decree_creation'
     DECREE_REPEAL = 'decree_repeal'

--- a/modules/api/sync/package/geozone.py
+++ b/modules/api/sync/package/geozone.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+from typing import Optional
+
+class Geozone:
+    def __init__(self, id: Optional[int], external_id: str, geometry):
+        self.id = id
+        self.external_id = external_id
+        self.geometry = geometry

--- a/modules/api/sync/package/geozone_repository.py
+++ b/modules/api/sync/package/geozone_repository.py
@@ -1,6 +1,25 @@
-def find_by_external_id(cursor, external_id: str):
-    query = 'SELECT id FROM geozone WHERE id_zone = %s'
+from typing import Optional
+
+from geozone import Geozone
+
+def find_by_external_id(cursor, external_id: str) -> Optional[Geozone]:
+    query = 'SELECT id, external_id, geometry FROM geozone WHERE external_id = %s'
     parameters = (external_id,)
     cursor.execute(query, parameters)
+    result = cursor.fetchone()
 
-    return cursor.fetchone()
+    if not result:
+        return None
+
+    return Geozone(
+        id=result.get('id'),
+        external_id=result.get('external_id'),
+        geometry=result.get('geometry'),
+    )
+
+def insert(cursor, geozone: Geozone) -> int:
+    query = 'INSERT INTO geozone (external_id, geometry) VALUES (%s, %s) RETURNING id;'
+    parameters = (geozone.external_id, geozone.geometry)
+    cursor.execute(query, parameters)
+
+    return cursor.fetchone()[0]

--- a/modules/api/sync/package/requirements.txt
+++ b/modules/api/sync/package/requirements.txt
@@ -1,3 +1,4 @@
 psycopg2
 requests
 email-validator
+geopandas


### PR DESCRIPTION
The `ogr2ogr` command has been replaced by the updated sync lambda.  
Extra fields of geozone entity has been removed to the benefit of
simplicity and at the expense of debugging capability.  
We assume that a geozone is never updated, instead we receive a new
one with its version incremented.  